### PR TITLE
Show both images in a single view with a slider

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,69 +3,68 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenSeaDragon Parallel Images Example</title>
+    <title>OpenSeaDragon Spit View Example</title>
     <style>
-        #openseadragon {
-            width: 100%;
-            height: 600px;
+        #viewer1, #viewer2 {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 50%;
+            height: 100%;
         }
-        .image-buttons {
-            margin: 10px 0;
+        #viewer1 {
+            left: 0;
         }
-        .image-buttons button {
-            margin-right: 10px;
+        #viewer2 {
+            right: 0;
         }
     </style>
 </head>
 <body>
-    <div class="image-buttons">
-        <button data-image="images/O48-013.dzi">XPL</button>
-        <button data-image="images/O48-014.dzi">PPL</button>
-    </div>
-    <div id="openseadragon"></div>
+    <div id="viewer1"></div>
+    <div id="viewer2"></div>
     <script src="js/openseadragon.min.js"></script>
-    <script src="js/openseadragon-scalebar.min.js"></script>
     <script>
-        var viewer = OpenSeadragon({
-            id: "openseadragon",
+        var viewer1 = OpenSeadragon({
+            id: "viewer1",
             prefixUrl: "js/images/",
             tileSources: "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi"
         });
 
-        viewer.scalebar({
-            type: OpenSeadragon.ScalebarType.MAP,
-            pixelsPerMeter: 100000,
-            minWidth: "75px",
-            location: OpenSeadragon.ScalebarLocation.BOTTOM_LEFT,
-            xOffset: 5,
-            yOffset: 10,
-            stayInsideImage: true,
-            color: "rgb(150, 150, 150)",
-            fontColor: "rgb(255, 0, 0)",
-            backgroundColor: "rgba(255, 255, 255, 0.75)",
-            fontSize: "small",
-            barThickness: 2
+        var viewer2 = OpenSeadragon({
+            id: "viewer2",
+            prefixUrl: "js/images/",
+            tileSources: "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-014.dzi"
         });
 
-        document.querySelectorAll('.image-buttons button').forEach(function(button) {
-            button.addEventListener('click', function() {
-                var tileSource = button.getAttribute('data-image');
-
-                // Save the current zoom and center
-                var currentZoom = viewer.viewport.getZoom();
-                var currentCenter = viewer.viewport.getCenter();
-
-                viewer.addHandler('open', function() {
-                    // Restore the zoom and center
-                    viewer.viewport.zoomTo(currentZoom, null, true);
-                    viewer.viewport.panTo(currentCenter, true);
-                }, {once: true});
-
-                // Open the new image
-                viewer.open(tileSource);
+        function synchronizeViewers(master, slave) {
+            master.addHandler('animation', function() {
+                var masterCenter = master.viewport.getCenter();
+                var masterZoom = master.viewport.getZoom();
+                slave.viewport.panTo(masterCenter, true);
+                slave.viewport.zoomTo(masterZoom, null, true);
             });
-        });
 
+            master.addHandler('resize', function() {
+                slave.viewport.viewportToImageRectangle(master.viewport.getBounds(true));
+            });
+        }
+
+        synchronizeViewers(viewer1, viewer2);
+        synchronizeViewers(viewer2, viewer1);
+
+        document.body.addEventListener('mousemove', function(event) {
+            var width = window.innerWidth;
+            var mouseX = event.clientX;
+
+            if (mouseX < width / 2) {
+                viewer1.container.style.width = '100%';
+                viewer2.container.style.width = '0%';
+            } else {
+                viewer1.container.style.width = '0%';
+                viewer2.container.style.width = '100%';
+            }
+        });
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>OpenSeaDragon Spit View Example</title>
+    <title>OpenSeaDragon Split View Example</title>
     <style>
         body, html {
             margin: 0;
@@ -19,7 +19,7 @@
             position: absolute;
             top: 0;
             bottom: 0;
-            overflow: hidden;
+            height: 100%;
         }
         #viewer1 {
             left: 0;

--- a/index.html
+++ b/index.html
@@ -20,6 +20,7 @@
             top: 0;
             bottom: 0;
             height: 100%;
+            width: 50%;
         }
         #viewer1 {
             left: 0;

--- a/index.html
+++ b/index.html
@@ -15,18 +15,10 @@
             width: 100%;
             height: 100%;
         }
-        #viewer1, #viewer2 {
+        #viewer {
             position: absolute;
-            top: 0;
-            bottom: 0;
             height: 100%;
-            width: 50%;
-        }
-        #viewer1 {
-            left: 0;
-        }
-        #viewer2 {
-            right: 0;
+            width: 100%;
         }
         #divider {
             position: absolute;
@@ -34,88 +26,67 @@
             bottom: 0;
             width: 2px;
             background: black;
-            cursor: ew-resize;
+            pointer-events: none;
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OpenSeadragonScalebar/2.0.0/openseadragon-scalebar.min.css" />
 </head>
 <body>
     <div id="viewer-container">
-        <div id="viewer1"></div>
-        <div id="viewer2"></div>
+        <div id="viewer"></div>
         <div id="divider"></div>
     </div>
     <script src="js/openseadragon.min.js"></script>
     <script src="js/openseadragon-scalebar.min.js"></script>
     <script>
-        var viewer1 = OpenSeadragon({
-            id: "viewer1",
+        const viewer = OpenSeadragon({
+            id: "viewer",
             prefixUrl: "js/images/",
-            tileSources: "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi"
+            tileSources: [
+                "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi",
+                "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-014.dzi",
+            ]
         });
 
-        var viewer2 = OpenSeadragon({
-            id: "viewer2",
-            prefixUrl: "js/images/",
-            tileSources: "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-014.dzi"
+        const divider = document.getElementById('divider');
+        const viewerContainer = document.getElementById('viewer-container');
+
+        // Keep track of the mouse's position outside the pointermove event so
+        // that it's available when handling other events, such as viewer
+        // animation.
+        let mousePos = new OpenSeadragon.Point(0, 0);
+
+        // Sets the dividing line between the two images at the given
+        // x-coordinate in window space.
+        const divideAtX = x => {
+            // Reposition the divider between the partial images.
+            divider.style.left = x + 'px';
+
+            // Clip the overlayed image to show only the region to the right of
+            // x, exposing the image underneath.
+            const overlay = viewer.world.getItemAt(1);
+            const clipPos = overlay.viewerElementToImageCoordinates(new OpenSeadragon.Point(x, 0));
+            // Clamp the clip to within the image bounds.
+            const size = overlay.getContentSize();
+            const xClip = Math.max(0, Math.min(clipPos.x, size.x));
+            overlay.setClip(new OpenSeadragon.Rect(xClip, 0, size.x, size.y));
+        };
+        // Sets the dividing line to the current mouse position.
+        const divideAtMouse = () => { divideAtX(mousePos.x); };
+        // Sets the dividing line to the center of the window.
+        const divideAtCenter = () => { divideAtX(document.body.clientWidth / 2); };
+
+        viewer.addHandler('animation', divideAtMouse);
+
+        viewerContainer.addEventListener('pointermove', event => {
+            mousePos = new OpenSeadragon.Point(event.clientX, event.clientY);
+            divideAtMouse();
         });
 
-        function synchronizeViewers(master, slave) {
-            master.addHandler('animation', function() {
-                var masterCenter = master.viewport.getCenter();
-                var masterZoom = master.viewport.getZoom();
-                slave.viewport.panTo(masterCenter, true);
-                slave.viewport.zoomTo(masterZoom, null, true);
-            });
+        document.addEventListener('mouseleave', divideAtCenter);
 
-            master.addHandler('resize', function() {
-                slave.viewport.viewportToImageRectangle(master.viewport.getBounds(true));
-            });
-        }
-
-        synchronizeViewers(viewer1, viewer2);
-        synchronizeViewers(viewer2, viewer1);
-
-        var divider = document.getElementById('divider');
-        var viewerContainer = document.getElementById('viewer-container');
-
-        viewerContainer.addEventListener('mousemove', function(event) {
-            var width = viewerContainer.clientWidth;
-            var mouseX = event.clientX;
-            var leftWidth = mouseX;
-            var rightWidth = width - mouseX;
-
-            viewer1.style.width = leftWidth + 'px';
-            viewer2.style.width = rightWidth + 'px';
-            viewer2.style.left = leftWidth + 'px';
-            divider.style.left = mouseX + 'px';
-        });
-
-        viewerContainer.addEventListener('mouseleave', function(event) {
-            viewer1.style.width = '50%';
-            viewer2.style.width = '50%';
-            viewer2.style.left = '50%';
-            divider.style.left = '50%';
-        });
-        
-        // Adding scalebar to viewer1
-        viewer1.scalebar({
-            type: OpenSeadragon.ScalebarType.MAP,
-            pixelsPerMeter: 100000, // Adjust according to your image
-            minWidth: "75px",
-            location: OpenSeadragon.ScalebarLocation.BOTTOM_LEFT,
-            xOffset: 10,
-            yOffset: 10,
-            stayInsideImage: true,
-            color: "black",
-            fontColor: "black",
-            backgroundColor: "rgba(255, 255, 255, 0.5)",
-            fontSize: "small",
-            barThickness: 2
-        });
-
-        // Adding scalebar to viewer2
-        viewer2.scalebar({
+        // Adding scalebar to viewer
+        viewer.scalebar({
             type: OpenSeadragon.ScalebarType.MAP,
             pixelsPerMeter: 100000, // Adjust according to your image
             minWidth: "75px",

--- a/index.html
+++ b/index.html
@@ -9,7 +9,17 @@
             position: absolute;
             top: 0;
             bottom: 0;
-            width: 50%;
+            overflow: hidden;
+        }
+        #viewer-container {
+            position: relative;
+            width: 100%;
+            height: 100%;
+        }
+        #viewer1, #viewer2 {
+            position: absolute;
+            top: 0;
+            bottom: 0;
             height: 100%;
         }
         #viewer1 {
@@ -18,11 +28,22 @@
         #viewer2 {
             right: 0;
         }
+        #divider {
+            position: absolute;
+            top: 0;
+            bottom: 0;
+            width: 2px;
+            background: black;
+            cursor: ew-resize;
+        }
     </style>
 </head>
 <body>
-    <div id="viewer1"></div>
-    <div id="viewer2"></div>
+    <div id="viewer-container">
+        <div id="viewer1"></div>
+        <div id="viewer2"></div>
+        <div id="divider"></div>
+    </div>
     <script src="js/openseadragon.min.js"></script>
     <script>
         var viewer1 = OpenSeadragon({
@@ -49,21 +70,30 @@
                 slave.viewport.viewportToImageRectangle(master.viewport.getBounds(true));
             });
         }
-        // Stuff
+
         synchronizeViewers(viewer1, viewer2);
         synchronizeViewers(viewer2, viewer1);
 
-        document.body.addEventListener('mousemove', function(event) {
-            var width = window.innerWidth;
-            var mouseX = event.clientX;
+        var divider = document.getElementById('divider');
+        var viewerContainer = document.getElementById('viewer-container');
 
-            if (mouseX < width / 2) {
-                viewer1.container.style.width = '100%';
-                viewer2.container.style.width = '0%';
-            } else {
-                viewer1.container.style.width = '0%';
-                viewer2.container.style.width = '100%';
-            }
+        viewerContainer.addEventListener('mousemove', function(event) {
+            var width = viewerContainer.clientWidth;
+            var mouseX = event.clientX;
+            var leftWidth = mouseX;
+            var rightWidth = width - mouseX;
+
+            viewer1.style.width = leftWidth + 'px';
+            viewer2.style.width = rightWidth + 'px';
+            viewer2.style.left = leftWidth + 'px';
+            divider.style.left = mouseX + 'px';
+        });
+
+        viewerContainer.addEventListener('mouseleave', function(event) {
+            viewer1.style.width = '50%';
+            viewer2.style.width = '50%';
+            viewer2.style.left = '50%';
+            divider.style.left = '50%';
         });
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
                 slave.viewport.viewportToImageRectangle(master.viewport.getBounds(true));
             });
         }
-
+        // Stuff
         synchronizeViewers(viewer1, viewer2);
         synchronizeViewers(viewer2, viewer1);
 

--- a/index.html
+++ b/index.html
@@ -5,10 +5,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>OpenSeaDragon Spit View Example</title>
     <style>
-        #viewer1, #viewer2 {
-            position: absolute;
-            top: 0;
-            bottom: 0;
+        body, html {
+            margin: 0;
+            height: 100%;
             overflow: hidden;
         }
         #viewer-container {
@@ -20,7 +19,7 @@
             position: absolute;
             top: 0;
             bottom: 0;
-            height: 100%;
+            overflow: hidden;
         }
         #viewer1 {
             left: 0;


### PR DESCRIPTION
@grsharman

This is branched from [`overlay_view`](https://github.com/grsharman/petro-image/tree/overlay_view) (here's the [diff with that branch](https://github.com/grsharman/petro-image/compare/overlay_view...overlay_view_single_viewer)), but I think it could be merged to `main` in place of that branch.

`overlay_view` shows both images side-by-side in two separate OpenSeadragon viewers. This PR instead combines these two viewers into one, containing both images superimposed. The mouse can then be used to slide between the top and bottom images by hovering. The key was [`TiledImages.setClip`](https://openseadragon.github.io/docs/OpenSeadragon.TiledImage.html#setClip), which allows the top image to be clipped/masked so that the bottom image is partially visible.