### PR TITLE
Allow three images to be overlaid

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,11 +15,6 @@
             width: 100%;
             height: 100%;
         }
-        #viewer {
-            position: absolute;
-            height: 100%;
-            width: 100%;
-        }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OpenSeadragonScalebar/2.0.0/openseadragon-scalebar.min.css" />
 </head>

--- a/index.html
+++ b/index.html
@@ -40,21 +40,16 @@
 
         const viewerContainer = document.getElementById('viewer-container');
 
-        // Share mouse position and division point data between different event
-        // handlers.
-        let mousePos = null;
-        let divisionPoint = new OpenSeadragon.Point(0, 0);
+        // Share the mouse position between event handlers.
+        let mousePos = new OpenSeadragon.Point(0, 0);
 
-        // Divides the images at the current division point (either the mouse
-        // position or the center of the window), clipping overlaid images to
-        // expose the images underneath. Note that all images are expected to
-        // have the same position and size.
+        // Divides the images at the current mouse position, clipping overlaid
+        // images to expose the images underneath. Note that all images are
+        // expected to have the same position and size.
         const divideImages = () => {
-            divisionPoint = mousePos || new OpenSeadragon.Point(document.body.clientWidth / 2, document.body.clientHeight / 2);
-
             const overlay1 = viewer.world.getItemAt(1);
             const overlay2 = viewer.world.getItemAt(2);
-            const clipPos = overlay1.viewerElementToImageCoordinates(divisionPoint);
+            const clipPos = overlay1.viewerElementToImageCoordinates(mousePos);
 
             // Clamp the clip point to within the image bounds.
             const size = overlay1.getContentSize();
@@ -85,26 +80,22 @@
 
             const ctx = viewer.drawer.context;
             ctx.lineWidth = 2;
-            if (divisionPoint.y >= top && divisionPoint.y <= bottom) {
+            if (mousePos.y >= top && mousePos.y <= bottom) {
                 ctx.beginPath();
-                ctx.moveTo(left, divisionPoint.y);
-                ctx.lineTo(right, divisionPoint.y);
+                ctx.moveTo(left, mousePos.y);
+                ctx.lineTo(right, mousePos.y);
                 ctx.stroke();
             }
-            if (divisionPoint.x >= left && divisionPoint.x <= right && divisionPoint.y >= top) {
+            if (mousePos.x >= left && mousePos.x <= right && mousePos.y >= top) {
                 ctx.beginPath();
-                ctx.moveTo(divisionPoint.x, top);
-                ctx.lineTo(divisionPoint.x, Math.min(divisionPoint.y, bottom));
+                ctx.moveTo(mousePos.x, top);
+                ctx.lineTo(mousePos.x, Math.min(mousePos.y, bottom));
                 ctx.stroke();
             }
         });
 
         viewerContainer.addEventListener('pointermove', event => {
             mousePos = new OpenSeadragon.Point(event.clientX, event.clientY)
-            divideImages();
-        });
-        document.addEventListener('mouseleave', () => {
-            mousePos = null;
             divideImages();
         });
 

--- a/index.html
+++ b/index.html
@@ -52,8 +52,8 @@
             const yClip = Math.max(0, Math.min(clipPos.y, size.y));
 
             // Set clips.
-            overlay1.setClip(new OpenSeadragon.Rect(0, 0, xClip, yClip));
-            overlay2.setClip(new OpenSeadragon.Rect(xClip, 0, size.x, yClip));
+            overlay1.setClip(new OpenSeadragon.Rect(xClip, 0,  size.x, yClip));
+            overlay2.setClip(new OpenSeadragon.Rect(0, yClip, size.x, size.y));
         };
 
         viewer.addHandler('animation', divideImages);

--- a/index.html
+++ b/index.html
@@ -20,70 +20,93 @@
             height: 100%;
             width: 100%;
         }
-        #divider {
-            position: absolute;
-            top: 0;
-            bottom: 0;
-            width: 2px;
-            background: black;
-            pointer-events: none;
-        }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OpenSeadragonScalebar/2.0.0/openseadragon-scalebar.min.css" />
 </head>
 <body>
-    <div id="viewer-container">
-        <div id="viewer"></div>
-        <div id="divider"></div>
-    </div>
+    <div id="viewer-container"></div>
     <script src="js/openseadragon.min.js"></script>
     <script src="js/openseadragon-scalebar.min.js"></script>
     <script>
         const viewer = OpenSeadragon({
-            id: "viewer",
+            id: "viewer-container",
             prefixUrl: "js/images/",
             tileSources: [
                 "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi",
                 "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-014.dzi",
+                "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi",
             ]
         });
 
-        const divider = document.getElementById('divider');
         const viewerContainer = document.getElementById('viewer-container');
 
-        // Keep track of the mouse's position outside the pointermove event so
-        // that it's available when handling other events, such as viewer
-        // animation.
-        let mousePos = new OpenSeadragon.Point(0, 0);
+        // Share mouse position and division point data between different event
+        // handlers.
+        let mousePos = null;
+        let divisionPoint = new OpenSeadragon.Point(0, 0);
 
-        // Sets the dividing line between the two images at the given
-        // x-coordinate in window space.
-        const divideAtX = x => {
-            // Reposition the divider between the partial images.
-            divider.style.left = x + 'px';
+        // Divides the images at the current division point (either the mouse
+        // position or the center of the window), clipping overlaid images to
+        // expose the images underneath. Note that all images are expected to
+        // have the same position and size.
+        const divideImages = () => {
+            divisionPoint = mousePos || new OpenSeadragon.Point(document.body.clientWidth / 2, document.body.clientHeight / 2);
 
-            // Clip the overlayed image to show only the region to the right of
-            // x, exposing the image underneath.
-            const overlay = viewer.world.getItemAt(1);
-            const clipPos = overlay.viewerElementToImageCoordinates(new OpenSeadragon.Point(x, 0));
-            // Clamp the clip to within the image bounds.
-            const size = overlay.getContentSize();
+            const overlay1 = viewer.world.getItemAt(1);
+            const overlay2 = viewer.world.getItemAt(2);
+            const clipPos = overlay1.viewerElementToImageCoordinates(divisionPoint);
+
+            // Clamp the clip point to within the image bounds.
+            const size = overlay1.getContentSize();
             const xClip = Math.max(0, Math.min(clipPos.x, size.x));
-            overlay.setClip(new OpenSeadragon.Rect(xClip, 0, size.x, size.y));
+            const yClip = Math.max(0, Math.min(clipPos.y, size.y));
+
+            // Set clips.
+            overlay1.setClip(new OpenSeadragon.Rect(0, 0, xClip, yClip));
+            overlay2.setClip(new OpenSeadragon.Rect(xClip, 0, size.x, yClip));
         };
-        // Sets the dividing line to the current mouse position.
-        const divideAtMouse = () => { divideAtX(mousePos.x); };
-        // Sets the dividing line to the center of the window.
-        const divideAtCenter = () => { divideAtX(document.body.clientWidth / 2); };
 
-        viewer.addHandler('animation', divideAtMouse);
+        viewer.addHandler('animation', divideImages);
 
-        viewerContainer.addEventListener('pointermove', event => {
-            mousePos = new OpenSeadragon.Point(event.clientX, event.clientY);
-            divideAtMouse();
+        viewer.addHandler('update-viewport', () => {
+            // Draw lines dividing the images, directly on the viewer's canvas.
+
+            // This is gnarly, but I don't know that there's a better way to
+            // find the window-space bounds of a viewer image.
+            const image0 = viewer.world.getItemAt(0);
+            const topLeftViewport = image0.viewportToImageCoordinates(image0.getBounds().getTopLeft())
+            const topLeftWindow = image0.imageToWindowCoordinates(topLeftViewport);
+            const bottomRightViewport = image0.viewportToImageCoordinates(image0.getBounds().getBottomRight());
+            const bottomRightWindow = image0.imageToWindowCoordinates(bottomRightViewport);
+            const top = Math.ceil(topLeftWindow.y);
+            const bottom = Math.floor(bottomRightWindow.y);
+            const left = Math.ceil(topLeftWindow.x);
+            const right = Math.floor(bottomRightWindow.x);
+
+            const ctx = viewer.drawer.context;
+            ctx.lineWidth = 2;
+            if (divisionPoint.y >= top && divisionPoint.y <= bottom) {
+                ctx.beginPath();
+                ctx.moveTo(left, divisionPoint.y);
+                ctx.lineTo(right, divisionPoint.y);
+                ctx.stroke();
+            }
+            if (divisionPoint.x >= left && divisionPoint.x <= right && divisionPoint.y >= top) {
+                ctx.beginPath();
+                ctx.moveTo(divisionPoint.x, top);
+                ctx.lineTo(divisionPoint.x, Math.min(divisionPoint.y, bottom));
+                ctx.stroke();
+            }
         });
 
-        document.addEventListener('mouseleave', divideAtCenter);
+        viewerContainer.addEventListener('pointermove', event => {
+            mousePos = new OpenSeadragon.Point(event.clientX, event.clientY)
+            divideImages();
+        });
+        document.addEventListener('mouseleave', () => {
+            mousePos = null;
+            divideImages();
+        });
 
         // Adding scalebar to viewer
         viewer.scalebar({


### PR DESCRIPTION
This adds support for a third image, overlaid on the first two. Note that for testing purposes, I've just added a second copy of the third test image (since there are only two in the repo at the moment).

I also removed the div-based divider in favor of drawing the (now two) dividers directly on the viewer's underlying canvas. The div approach also worked, but this felt a little simpler.

And finally, I removed the behavior where the division point snaps to the center of the window when the mouse leaves the window. This simplifies the script a bit, and I think the UX is less jarring. (If you want that behavior back, I can just revert e51d289.)

## Future Enhancements ✨

@grsharman, I saw that you have [another branch](https://github.com/grsharman/petro-image/tree/overlay_view_wannotation) experimenting with a coordinates display and annotations. There are also some features on the [PiAutoStage](https://sites.google.com/msu.edu/piautostage/examples) page that I wonder if you're interested in, namely:

1. Buttons to hide/show individual images
2. Toggle button(s) for "curtain" vs. "sync" mode

Hit me up if you'd like help implementing any of the above!