### PR TITLE
Add grid overlay settings

### DIFF
--- a/index.html
+++ b/index.html
@@ -87,9 +87,9 @@
                 </div>
                 <div>
                     rows:
-                    <input id="row-count" class="coordinate-input" type="number" value="5" min="2"></input>
+                    <input id="row-count" class="coordinate-input" type="number" value="10" min="2"></input>
                     columns:
-                    <input id="col-count" class="coordinate-input" type="number" value="5" min="2"></input>
+                    <input id="col-count" class="coordinate-input" type="number" value="10" min="2"></input>
                 </div>
                 <button onclick="overlayGridPoints()">Apply</button>
                 <button>Import</button>
@@ -192,12 +192,20 @@
                     // Add crosshairs.
                     const crosshairs = document.createElement("div");
                     crosshairs.className = "crosshairs";
-                    viewer.addOverlay(crosshairs, location);
+                    viewer.addOverlay({
+                        element: crosshairs,
+                        location: location,
+                        checkResize: false,
+                    });
                     // Add point label with coordinates.
                     const pointLabel = document.createElement("div");
                     pointLabel.innerHTML = `${1 + col + row * colCount} (${x.toPrecision(3)}, ${y.toPrecision(3)})`;
                     pointLabel.className = "point-label";
-                    viewer.addOverlay(pointLabel, location);
+                    viewer.addOverlay({
+                        element: pointLabel,
+                        location: location,
+                        checkResize: false,
+                    });
                 }
             }
         };

--- a/index.html
+++ b/index.html
@@ -74,13 +74,13 @@
         <div>
             <details open>
                 <summary>Grid layout</summary>
-                <input id="pixels-per-meter" class="number-input" type="number" step="any" value="100" min="1"></input>
+                <input id="pixels-per-unit" class="number-input" type="number" step="any" value="100" min="1"></input>
                 pixels/
-                <select id="unit">
-                    <option value="1">m</option>
-                    <option value="1e-3" selected>mm</option>
-                    <option value="1e-6">μm</option>
-                    <option value="1e-9">nm</option>
+                <select id="meters-per-unit">
+                    <option value="1" label="m">m</option>
+                    <option value="1e-3" label = "mm" selected>mm</option>
+                    <option value="1e-6" label="μm">μm</option>
+                    <option value="1e-9" label="nm">nm</option>
                 </select>
                 <div>
                     <label for="grid-left">x<sub>min</sub>:</label>
@@ -90,9 +90,9 @@
                 </div>
                 <div>
                     <label for="grid-right">x<sub>max</sub>:</label>
-                    <input id="grid-right" class="number-input" type="number" step="any" value="1.0"></input>
+                    <input id="grid-right" class="number-input" type="number" step="any" value="20"></input>
                     <label for="grid-bottom">y<sub>max</sub>:</label>
-                    <input id="grid-bottom" class="number-input" type="number" step="any" value="1.0"></input>
+                    <input id="grid-bottom" class="number-input" type="number" step="any" value="20"></input>
                 </div>
                 <div>
                     <label for="row-count">rows:</label>
@@ -135,7 +135,7 @@
             }
 
             // Get the clip point and clamp it to within the image bounds.
-            const image = viewer.world.getItemAt(0)
+            const image = viewer.world.getItemAt(0);
             const clipPos = image.viewerElementToImageCoordinates(mousePos);
             const size = image.getContentSize();
             clipPos.x = Math.max(0, Math.min(clipPos.x, size.x));
@@ -199,8 +199,11 @@
         const overlayGridPoints = () => {
             viewer.clearOverlays();
 
-            const unit = parseFloat(document.getElementById("unit").value);
-            grid.pixelsPerMeter = parseFloat(document.getElementById("pixels-per-meter").value) / unit;
+            const image = viewer.world.getItemAt(0);
+            const metersPerUnitSelect = document.getElementById("meters-per-unit");
+            const metersPerUnit = parseFloat(metersPerUnitSelect.value);
+            const unitLabel = metersPerUnitSelect.options[metersPerUnitSelect.selectedIndex].label;
+            grid.pixelsPerMeter = parseFloat(document.getElementById("pixels-per-unit").value) / metersPerUnit;
             grid.xMin = parseFloat(document.getElementById("grid-left").value);
             grid.yMin = parseFloat(document.getElementById("grid-top").value);
             grid.xMax = parseFloat(document.getElementById("grid-right").value);
@@ -212,24 +215,36 @@
 
             for (let row = 0; row < grid.rows; ++row) {
                 for (let col = 0; col < grid.cols; ++col) {
-                    // Alternate column order.
-                    const x = grid.xMin + (row % 2 == 0 ? col : grid.cols - col - 1) * colWidth;
-                    const y = grid.yMin + row * rowHeight;
-                    const location = new OpenSeadragon.Point(x, y);
+                    // Alternate column order per row.
+                    const altCol = row % 2 == 0 ? col : grid.cols - col - 1;
+
+                    // Get the coordinates in the specified unit.
+                    const xUnits = grid.xMin + altCol * colWidth;
+                    const yUnits = grid.yMin + row * rowHeight;
+
+                    // Convert to coordinates in pixels.
+                    const xPixels = xUnits * metersPerUnit * grid.pixelsPerMeter;
+                    const yPixels = yUnits * metersPerUnit * grid.pixelsPerMeter;
+
+                    // Convert to view-space coordinates, measuring from the
+                    // top-left of the first image.
+                    const location = image.imageToViewportCoordinates(xPixels, yPixels);
+
+                    // Add point label with coordinates.
+                    const pointLabel = document.createElement("div");
+                    pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${unitLabel}, ${yUnits.toPrecision(3)} ${unitLabel})`;
+                    pointLabel.className = "point-label";
+                    viewer.addOverlay({
+                        element: pointLabel,
+                        location: location,
+                        checkResize: false,
+                    });
+
                     // Add crosshairs.
                     const crosshairs = document.createElement("div");
                     crosshairs.className = "crosshairs";
                     viewer.addOverlay({
                         element: crosshairs,
-                        location: location,
-                        checkResize: false,
-                    });
-                    // Add point label with coordinates.
-                    const pointLabel = document.createElement("div");
-                    pointLabel.innerHTML = `${1 + col + row * grid.cols} (${x.toPrecision(3)}, ${y.toPrecision(3)})`;
-                    pointLabel.className = "point-label";
-                    viewer.addOverlay({
-                        element: pointLabel,
                         location: location,
                         checkResize: false,
                     });

--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
             transform: translate(-50%, -50%);
             background-color: red;
         }
-        .coordinate-input {
+        .number-input {
             width: 40px;
         }
     </style>
@@ -74,23 +74,31 @@
         <div>
             <details open>
                 <summary>Grid layout</summary>
+                <input id="pixels-per-meter" class="number-input" type="number" step="any" value="100" min="1"></input>
+                pixels/
+                <select id="unit">
+                    <option value="1">m</option>
+                    <option value="1e-3" selected>mm</option>
+                    <option value="1e-6">μm</option>
+                    <option value="1e-9">nm</option>
+                </select>
                 <div>
-                    x<sub>min</sub>:
-                    <input id="grid-left" class="coordinate-input" type="number" step="any" value="0" min="0"></input>
-                    y<sub>min</sub>:
-                    <input id="grid-top" class="coordinate-input" type="number" step="any" value="0" min="0"></input>
+                    <label for="grid-left">x<sub>min</sub>:</label>
+                    <input id="grid-left" class="number-input" type="number" step="any" value="0" min="0"></input>
+                    <label for="grid-top">y<sub>min</sub>:</label>
+                    <input id="grid-top" class="number-input" type="number" step="any" value="0" min="0"></input>
                 </div>
                 <div>
-                    x<sub>max</sub>:
-                    <input id="grid-right" class="coordinate-input" type="number" step="any" value="1.0"></input>
-                    y<sub>max</sub>:
-                    <input id="grid-bottom" class="coordinate-input" type="number" step="any" value="1.0"></input>
+                    <label for="grid-right">x<sub>max</sub>:</label>
+                    <input id="grid-right" class="number-input" type="number" step="any" value="1.0"></input>
+                    <label for="grid-bottom">y<sub>max</sub>:</label>
+                    <input id="grid-bottom" class="number-input" type="number" step="any" value="1.0"></input>
                 </div>
                 <div>
-                    rows:
-                    <input id="row-count" class="coordinate-input" type="number" value="10" min="2"></input>
-                    columns:
-                    <input id="col-count" class="coordinate-input" type="number" value="10" min="2"></input>
+                    <label for="row-count">rows:</label>
+                    <input id="row-count" class="number-input" type="number" value="10" min="2"></input>
+                    <label for="col-count">columns:</label>
+                    <input id="col-count" class="number-input" type="number" value="10" min="2"></input>
                 </div>
                 <button onclick="overlayGridPoints()">Apply</button>
                 <button>Import</button>
@@ -161,10 +169,10 @@
             divideImages();
         });
 
-        // Adding scalebar to viewer
+        // Initialize the scalebar, except for pixelsPerMeter, which depends on
+        // the grid settings.
         viewer.scalebar({
             type: OpenSeadragon.ScalebarType.MAP,
-            pixelsPerMeter: 100000, // Adjust according to your image
             minWidth: "75px",
             location: OpenSeadragon.ScalebarLocation.BOTTOM_LEFT,
             xOffset: 10,
@@ -177,23 +185,36 @@
             barThickness: 2
         });
 
+        // Initialize default grid.
+        let grid = {
+            pixelsPerMeter: 100_000,
+            xMin: 0,
+            yMin: 0,
+            xMax: 1,
+            yMax: 1,
+            rows: 10,
+            cols: 10
+        };
+
         const overlayGridPoints = () => {
             viewer.clearOverlays();
 
-            const gridTop = parseFloat(document.getElementById("grid-top").value);
-            const gridLeft = parseFloat(document.getElementById("grid-left").value);
-            const gridBottom = parseFloat(document.getElementById("grid-bottom").value);
-            const gridRight = parseFloat(document.getElementById("grid-right").value);
-            const rowCount = parseInt(document.getElementById("row-count").value);
-            const colCount = parseInt(document.getElementById("col-count").value);
-            const rowHeight = (gridBottom - gridTop) / (rowCount - 1);
-            const colWidth = (gridRight - gridLeft) / (colCount - 1);
+            const unit = parseFloat(document.getElementById("unit").value);
+            grid.pixelsPerMeter = parseFloat(document.getElementById("pixels-per-meter").value) / unit;
+            grid.xMin = parseFloat(document.getElementById("grid-left").value);
+            grid.yMin = parseFloat(document.getElementById("grid-top").value);
+            grid.xMax = parseFloat(document.getElementById("grid-right").value);
+            grid.yMax = parseFloat(document.getElementById("grid-bottom").value);
+            grid.rows = parseInt(document.getElementById("row-count").value);
+            grid.cols = parseInt(document.getElementById("col-count").value);
+            const rowHeight = (grid.yMax - grid.yMin) / (grid.rows - 1);
+            const colWidth = (grid.xMax - grid.xMin) / (grid.cols - 1);
 
-            for (let row = 0; row < rowCount; ++row) {
-                for (let col = 0; col < colCount; ++col) {
+            for (let row = 0; row < grid.rows; ++row) {
+                for (let col = 0; col < grid.cols; ++col) {
                     // Alternate column order.
-                    const x = gridLeft + (row % 2 == 0 ? col : colCount - col - 1) * colWidth;
-                    const y = gridTop + row * rowHeight;
+                    const x = grid.xMin + (row % 2 == 0 ? col : grid.cols - col - 1) * colWidth;
+                    const y = grid.yMin + row * rowHeight;
                     const location = new OpenSeadragon.Point(x, y);
                     // Add crosshairs.
                     const crosshairs = document.createElement("div");
@@ -205,7 +226,7 @@
                     });
                     // Add point label with coordinates.
                     const pointLabel = document.createElement("div");
-                    pointLabel.innerHTML = `${1 + col + row * colCount} (${x.toPrecision(3)}, ${y.toPrecision(3)})`;
+                    pointLabel.innerHTML = `${1 + col + row * grid.cols} (${x.toPrecision(3)}, ${y.toPrecision(3)})`;
                     pointLabel.className = "point-label";
                     viewer.addOverlay({
                         element: pointLabel,
@@ -214,6 +235,9 @@
                     });
                 }
             }
+
+            // Update scalebar scale.
+            viewer.scalebar({pixelsPerMeter: grid.pixelsPerMeter});
         };
     </script>
 </body>

--- a/index.html
+++ b/index.html
@@ -19,7 +19,41 @@
             position: absolute;
             top: 40px;
             left: 5px;
-            background-color: rgba(255, 255, 255, 0.5); 
+            border: 1px solid black;
+            border-radius: 4px;
+            padding: 5px;
+            background-color: rgba(255, 255, 255, 0.75);
+        }
+        .point-label {
+            position: absolute;
+            transform: translateY(-100%);
+            padding: 0px 5px;
+            border-radius: 9999px;
+            color: white;
+            background-color: rgba(0, 0, 0, 0.5);
+        }
+        .crosshairs {
+            position: absolute;
+            transform: translate(-50%, -50%);
+        }
+        .crosshairs::before {
+            content: "";
+            position: absolute;
+            width: 12px;
+            height: 2px;
+            transform: translate(-50%, -50%);
+            background-color: red;
+        }
+        .crosshairs::after {
+            content: "";
+            position: absolute;
+            width: 2px;
+            height: 12px;
+            transform: translate(-50%, -50%);
+            background-color: red;
+        }
+        .coordinate-input {
+            width: 40px;
         }
     </style>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OpenSeadragonScalebar/2.0.0/openseadragon-scalebar.min.css" />
@@ -27,12 +61,42 @@
 <body>
     <div id="viewer-container"></div>
     <div class="controls">
-        <input type="checkbox" id="image1" checked onclick="toggleVisibility(this, 0)" />
-        <label for="image1">XPL1</label>
-        <input type="checkbox" id="image2" checked onclick="toggleVisibility(this, 1)" />
-        <label for="image2">XPL2</label>
-        <input type="checkbox" id="image3" checked onclick="toggleVisibility(this, 2)" />
-        <label for="image3">PPL</label>
+        <div>
+            <input type="checkbox" id="image1" checked onclick="toggleVisibility(this, 0)" />
+            <label for="image1">XPL1</label>
+            <input type="checkbox" id="image2" checked onclick="toggleVisibility(this, 1)" />
+            <label for="image2">XPL2</label>
+            <input type="checkbox" id="image3" checked onclick="toggleVisibility(this, 2)" />
+            <label for="image3">PPL</label>
+        </div>
+        <hr>
+        <div>
+            <details open>
+                <summary>Grid layout</summary>
+                <div>
+                    x<sub>min</sub>:
+                    <input id="grid-left" class="coordinate-input" type="number" step="any" value="0" min="0"></input>
+                    y<sub>min</sub>:
+                    <input id="grid-top" class="coordinate-input" type="number" step="any" value="0" min="0"></input>
+                </div>
+                <div>
+                    x<sub>max</sub>:
+                    <input id="grid-right" class="coordinate-input" type="number" step="any" value="1.0"></input>
+                    y<sub>max</sub>:
+                    <input id="grid-bottom" class="coordinate-input" type="number" step="any" value="1.0"></input>
+                </div>
+                <div>
+                    rows:
+                    <input id="row-count" class="coordinate-input" type="number" value="5" min="2"></input>
+                    columns:
+                    <input id="col-count" class="coordinate-input" type="number" value="5" min="2"></input>
+                </div>
+                <button onclick="overlayGridPoints()">Apply</button>
+                <button>Import</button>
+                <button>Export</button>
+            </details>
+        </div>
+    </div>
     </div>
     <script src="js/openseadragon.min.js"></script>
     <script src="js/openseadragon-scalebar.min.js"></script>
@@ -106,6 +170,37 @@
             fontSize: "small",
             barThickness: 2
         });
+
+        const overlayGridPoints = () => {
+            viewer.clearOverlays();
+
+            const gridTop = parseFloat(document.getElementById("grid-top").value);
+            const gridLeft = parseFloat(document.getElementById("grid-left").value);
+            const gridBottom = parseFloat(document.getElementById("grid-bottom").value);
+            const gridRight = parseFloat(document.getElementById("grid-right").value);
+            const rowCount = parseInt(document.getElementById("row-count").value);
+            const colCount = parseInt(document.getElementById("col-count").value);
+            const rowHeight = (gridBottom - gridTop) / (rowCount - 1);
+            const colWidth = (gridRight - gridLeft) / (colCount - 1);
+
+            for (let row = 0; row < rowCount; ++row) {
+                for (let col = 0; col < colCount; ++col) {
+                    // Alternate column order.
+                    const x = gridLeft + (row % 2 == 0 ? col : colCount - col - 1) * colWidth;
+                    const y = gridTop + row * rowHeight;
+                    const location = new OpenSeadragon.Point(x, y);
+                    // Add crosshairs.
+                    const crosshairs = document.createElement("div");
+                    crosshairs.className = "crosshairs";
+                    viewer.addOverlay(crosshairs, location);
+                    // Add point label with coordinates.
+                    const pointLabel = document.createElement("div");
+                    pointLabel.innerHTML = `${1 + col + row * colCount} (${x.toPrecision(3)}, ${y.toPrecision(3)})`;
+                    pointLabel.className = "point-label";
+                    viewer.addOverlay(pointLabel, location);
+                }
+            }
+        };
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
             position: absolute;
             transform: translateY(-100%);
             padding: 0px 5px;
-            border-radius: 9999px;
+            border-radius: 9999px 9999px 9999px 0px;
             color: white;
             background-color: rgba(0, 0, 0, 0.5);
             white-space: nowrap;

--- a/index.html
+++ b/index.html
@@ -31,6 +31,7 @@
             border-radius: 9999px;
             color: white;
             background-color: rgba(0, 0, 0, 0.5);
+            white-space: nowrap;
         }
         .crosshairs {
             position: absolute;

--- a/index.html
+++ b/index.html
@@ -63,46 +63,47 @@
     <div id="viewer-container"></div>
     <div class="controls">
         <div>
-            <input type="checkbox" id="image1" checked onclick="toggleVisibility(this, 0)" />
+            <input type="checkbox" id="image1" checked onclick="toggleImage(this, 0)" />
             <label for="image1">XPL1</label>
-            <input type="checkbox" id="image2" checked onclick="toggleVisibility(this, 1)" />
+            <input type="checkbox" id="image2" checked onclick="toggleImage(this, 1)" />
             <label for="image2">XPL2</label>
-            <input type="checkbox" id="image3" checked onclick="toggleVisibility(this, 2)" />
+            <input type="checkbox" id="image3" checked onclick="toggleImage(this, 2)" />
             <label for="image3">PPL</label>
         </div>
         <hr>
         <div>
+            <input type="checkbox" id="show-grid" checked onclick="toggleGrid(this)" />
+            <label for="show-grid">Show grid</label>
             <details open>
                 <summary>Grid layout</summary>
-                <input id="pixels-per-unit" class="number-input" type="number" step="any" value="100" min="1"></input>
+                <input id="pixels-per-unit" class="number-input" type="number" step="any" value="100" min="1" onchange="enableGridButtons()"></input>
                 pixels/
-                <select id="meters-per-unit">
-                    <option value="1" label="m">m</option>
-                    <option value="1e-3" label = "mm" selected>mm</option>
-                    <option value="1e-6" label="μm">μm</option>
-                    <option value="1e-9" label="nm">nm</option>
+                <select id="unit" onchange="enableGridButtons()">
+                    <option>m</option>
+                    <option>mm</option>
+                    <option>μm</option>
+                    <option>nm</option>
                 </select>
                 <div>
                     <label for="grid-left">x<sub>min</sub>:</label>
-                    <input id="grid-left" class="number-input" type="number" step="any" value="0" min="0"></input>
+                    <input id="grid-left" class="number-input" type="number" step="any" min="0" onchange="enableGridButtons()"></input>
                     <label for="grid-top">y<sub>min</sub>:</label>
-                    <input id="grid-top" class="number-input" type="number" step="any" value="0" min="0"></input>
+                    <input id="grid-top" class="number-input" type="number" step="any" min="0" onchange="enableGridButtons()"></input>
                 </div>
                 <div>
                     <label for="grid-right">x<sub>max</sub>:</label>
-                    <input id="grid-right" class="number-input" type="number" step="any" value="20"></input>
+                    <input id="grid-right" class="number-input" type="number" step="any" onchange="enableGridButtons()"></input>
                     <label for="grid-bottom">y<sub>max</sub>:</label>
-                    <input id="grid-bottom" class="number-input" type="number" step="any" value="20"></input>
+                    <input id="grid-bottom" class="number-input" type="number" step="any" onchange="enableGridButtons()"></input>
                 </div>
                 <div>
                     <label for="row-count">rows:</label>
-                    <input id="row-count" class="number-input" type="number" value="10" min="2"></input>
+                    <input id="row-count" class="number-input" type="number" min="2" onchange="enableGridButtons()"></input>
                     <label for="col-count">columns:</label>
-                    <input id="col-count" class="number-input" type="number" value="10" min="2"></input>
+                    <input id="col-count" class="number-input" type="number" min="2" onchange="enableGridButtons()"></input>
                 </div>
-                <button onclick="overlayGridPoints()">Apply</button>
-                <button>Import</button>
-                <button>Export</button>
+                <button id="apply-grid-settings" onclick="applyGridSettings()">Apply</button>
+                <button id="restore-grid-settings" onclick="restoreGridSettings()" disabled>Restore</button>
             </details>
         </div>
     </div>
@@ -157,9 +158,15 @@
             }
         };
 
-        const toggleVisibility = (checkbox, idx) => {
+        const toggleImage = (checkbox, idx) => {
             viewer.world.getItemAt(idx).setOpacity(checkbox.checked ? 1 : 0);
             divideImages();
+        };
+
+        const toggleGrid = event => {
+            for (let el of document.getElementsByClassName("grid")) {
+                el.style.visibility = event.checked ? "visible" : "hidden";
+            }
         };
 
         viewer.addHandler('animation', divideImages);
@@ -185,33 +192,72 @@
             barThickness: 2
         });
 
-        // Initialize default grid.
-        let grid = {
-            pixelsPerMeter: 100_000,
-            xMin: 0,
-            yMin: 0,
-            xMax: 1,
-            yMax: 1,
-            rows: 10,
-            cols: 10
+        const Grid = class {
+            constructor({unit, pixelsPerUnit, xMin, yMin, xMax, yMax, rows, cols}) {
+                this.unit = unit;
+                this.pixelsPerUnit = pixelsPerUnit;
+                this.xMin = xMin;
+                this.yMin = yMin;
+                this.xMax = xMax;
+                this.yMax = yMax;
+                this.rows = rows;
+                this.cols = cols;
+            }
+
+            get metersPerUnit() {
+                return 10 ** (-3 * this.unit);
+            }
+
+            get unitName() {
+                switch (this.unit) {
+                    case 0:
+                        return "m";
+                    case 1:
+                        return "mm";
+                    case 2:
+                        return "μm";
+                    case 3:
+                        return "nm";
+                }
+            }
+
+            get pixelsPerMeter() {
+                return this.pixelsPerUnit / this.metersPerUnit;
+            }
         };
 
-        const overlayGridPoints = () => {
+        // Initialize grid with default settings.
+        let grid = new Grid({
+            unit: 1,
+            pixelsPerUnit: 100,
+            xMin: 1,
+            yMin: 3,
+            xMax: 48,
+            yMax: 28,
+            rows: 10,
+            cols: 10,
+        });
+        let gridApplied = false;
+
+        const enableGridButtons = () => {
+            document.getElementById("apply-grid-settings").disabled = false;
+            document.getElementById("restore-grid-settings").disabled = false;
+        };
+
+        const applyGridSettings = () => {
             viewer.clearOverlays();
 
             const image = viewer.world.getItemAt(0);
-            const metersPerUnitSelect = document.getElementById("meters-per-unit");
-            const metersPerUnit = parseFloat(metersPerUnitSelect.value);
-            const unitLabel = metersPerUnitSelect.options[metersPerUnitSelect.selectedIndex].label;
-            grid.pixelsPerMeter = parseFloat(document.getElementById("pixels-per-unit").value) / metersPerUnit;
-            grid.xMin = parseFloat(document.getElementById("grid-left").value);
-            grid.yMin = parseFloat(document.getElementById("grid-top").value);
-            grid.xMax = parseFloat(document.getElementById("grid-right").value);
-            grid.yMax = parseFloat(document.getElementById("grid-bottom").value);
-            grid.rows = parseInt(document.getElementById("row-count").value);
-            grid.cols = parseInt(document.getElementById("col-count").value);
-            const rowHeight = (grid.yMax - grid.yMin) / (grid.rows - 1);
-            const colWidth = (grid.xMax - grid.xMin) / (grid.cols - 1);
+            grid = new Grid({
+                unit: document.getElementById("unit").selectedIndex,
+                pixelsPerUnit: parseFloat(document.getElementById("pixels-per-unit").value),
+                xMin: parseFloat(document.getElementById("grid-left").value),
+                yMin: parseFloat(document.getElementById("grid-top").value),
+                xMax: parseFloat(document.getElementById("grid-right").value),
+                yMax: parseFloat(document.getElementById("grid-bottom").value),
+                rows: parseInt(document.getElementById("row-count").value),
+                cols: parseInt(document.getElementById("col-count").value),
+            });
 
             for (let row = 0; row < grid.rows; ++row) {
                 for (let col = 0; col < grid.cols; ++col) {
@@ -219,12 +265,12 @@
                     const altCol = row % 2 == 0 ? col : grid.cols - col - 1;
 
                     // Get the coordinates in the specified unit.
-                    const xUnits = grid.xMin + altCol * colWidth;
-                    const yUnits = grid.yMin + row * rowHeight;
+                    const xUnits = grid.xMin + altCol * (grid.xMax - grid.xMin) / (grid.cols - 1);
+                    const yUnits = grid.yMin + row * (grid.yMax - grid.yMin) / (grid.rows - 1);
 
                     // Convert to coordinates in pixels.
-                    const xPixels = xUnits * metersPerUnit * grid.pixelsPerMeter;
-                    const yPixels = yUnits * metersPerUnit * grid.pixelsPerMeter;
+                    const xPixels = xUnits * grid.metersPerUnit * grid.pixelsPerMeter;
+                    const yPixels = yUnits * grid.metersPerUnit * grid.pixelsPerMeter;
 
                     // Convert to view-space coordinates, measuring from the
                     // top-left of the first image.
@@ -232,8 +278,8 @@
 
                     // Add point label with coordinates.
                     const pointLabel = document.createElement("div");
-                    pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${unitLabel}, ${yUnits.toPrecision(3)} ${unitLabel})`;
-                    pointLabel.className = "point-label";
+                    pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${grid.unitName}, ${yUnits.toPrecision(3)} ${grid.unitName})`;
+                    pointLabel.className = "grid point-label";
                     viewer.addOverlay({
                         element: pointLabel,
                         location: location,
@@ -242,7 +288,7 @@
 
                     // Add crosshairs.
                     const crosshairs = document.createElement("div");
-                    crosshairs.className = "crosshairs";
+                    crosshairs.className = "grid crosshairs";
                     viewer.addOverlay({
                         element: crosshairs,
                         location: location,
@@ -253,7 +299,38 @@
 
             // Update scalebar scale.
             viewer.scalebar({pixelsPerMeter: grid.pixelsPerMeter});
+
+            // Always show the grid right after generating it. (The newly added
+            // overlay elements will be visible by default, so checking the box
+            // here doesn't actually affect them - it just makes the checkbox
+            // state consistent with the visibility states.)
+            document.getElementById("show-grid").checked = true;
+
+            document.getElementById("apply-grid-settings").disabled = true;
+            document.getElementById("restore-grid-settings").disabled = true;
+            gridApplied = true;
         };
+
+        const restoreGridSettings = () => {
+            document.getElementById("unit").selectedIndex = grid.unit;
+            document.getElementById("pixels-per-unit").value = grid.pixelsPerUnit;
+            document.getElementById("grid-left").value = grid.xMin;
+            document.getElementById("grid-top").value = grid.yMin;
+            document.getElementById("grid-right").value = grid.xMax;
+            document.getElementById("grid-bottom").value = grid.yMax;
+            document.getElementById("row-count").value = grid.rows;
+            document.getElementById("col-count").value = grid.cols;
+
+            // Leave the Apply button enabled unless the grid has been generated
+            // at least once.
+            if (gridApplied) {
+                document.getElementById("apply-grid-settings").disabled = true;
+            }
+            document.getElementById("restore-grid-settings").disabled = true;
+        }
+
+        // Initialize grid setting elements.
+        restoreGridSettings();
     </script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -121,6 +121,11 @@
         // images to expose the images underneath. Note that all images are
         // expected to have the same position and size.
         const divideImages = () => {
+            // Bail out if there are no images.
+            if (viewer.world.getItemCount() == 0) {
+                return;
+            }
+
             // Get the clip point and clamp it to within the image bounds.
             const image = viewer.world.getItemAt(0)
             const clipPos = image.viewerElementToImageCoordinates(mousePos);

--- a/index.html
+++ b/index.html
@@ -112,6 +112,7 @@
     <script src="js/openseadragon-scalebar.min.js"></script>
     <script>
         const viewer = OpenSeadragon({
+            maxZoomPixelRatio: 100,
             id: "viewer-container",
             prefixUrl: "js/images/",
             tileSources: [
@@ -278,7 +279,8 @@
 
                     // Add point label with coordinates.
                     const pointLabel = document.createElement("div");
-                    pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${grid.unitName}, ${yUnits.toPrecision(3)} ${grid.unitName})`;
+                    pointLabel.innerHTML = `${1 + col + row * grid.cols}`;                    
+                    // pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${grid.unitName}, ${yUnits.toPrecision(3)} ${grid.unitName})`;
                     pointLabel.className = "grid point-label";
                     viewer.addOverlay({
                         element: pointLabel,


### PR DESCRIPTION
This adds settings to the control panel for applying a grid overlay. The settings include show/hide, a distance unit dropdown, the number of that distance unit per pixel, start and end coordinates (specified in the selected unit), row/column counts, and apply/restore buttons.

![screenshot](https://github.com/user-attachments/assets/728417f9-6942-4ea8-bc35-cd6781e236c2)

Initially, the grid is not shown. When the Apply button is clicked, the grid is generated, with points assigned alternatingly left-to-right then right-to-left. Once the grid is applied, changing any grid settings will enable both Apply and Restore. Restore resets the inputs to their previous values, the last time they were applied. (To make it easier to tweak the grid, maybe we should consider updating the displayed grid as values are changed, but for now, you have to click Apply before anything visually changes.)

Internally, this adds a `Grid` data type that fully specifies the units and layout of the grid. This type should come in handy later on for saving and restoring image/grid/point data.

Note that I'm currently labeling each point with its coordinates, in addition to its index. These coordinates were handy for debugging, but they cause a lot of crowding when zoomed out, so we may want to remove them. (Later we could add mouseover coordinates and point coordinates in the not-yet-implemented point editor.)

Finally, I updated the scalebar so that it's hidden by default and then is initialized using the pixels/meter specified by the user.

### Performance Considerations

An important question for @grsharman: how many grid points does this tool need to support? On my machine, navigating with the grid on is quite smooth up to about 15 x 15 = 225 points. 20 x 20 = 400 is passable. 30 x 30 = 900 is still functional but definitely starting to feel unreasonably laggy. How many points will people realistically want to place at once? If it's much more than the 200-400 range, we may need to explore options to improve the performance.

### Future Work

Here's how I'm imagining the overall workflow once all the parts are implemented:

1. Load the previous app state, if any, from local storage.
2. Enter some Deep Zoom image URLs and optional image labels. (We can initialize the images from example URLs by default, as we're doing already.) Once at least one image is selected, the grid settings are enabled.
3. Setup the grid, using the controls added in this PR. Once the grid is applied, the data entry controls are enabled. If point data has already been entered, attempting to change the grid layout will pop up a warning dialog and then (if confirmed) clear out all the point data.
4. Click left and right through the points, adding labels and optional notes.
5. Export the point data in some other format, like CSV?

Any time something changes (images added/removed, grid settings applied, point data entered), we'll save everything back to local storage so it can be restored if the page is reloaded. In addition, we'll have save/load buttons for writing the app state to disk and loading it later, potentially on a different machine.