### PR TITLE
Split CSS and JS into separate files, format everything with Prettier

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,338 +1,139 @@
 <!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OpenSeaDragon Split View Example</title>
-    <style>
-        body, html {
-            margin: 0;
-            height: 100%;
-            overflow: hidden;
-        }
-        #viewer-container {
-            position: relative;
-            width: 100%;
-            height: 100%;
-        }
-        .controls {
-            position: absolute;
-            top: 40px;
-            left: 5px;
-            border: 1px solid black;
-            border-radius: 4px;
-            padding: 5px;
-            background-color: rgba(255, 255, 255, 0.75);
-        }
-        .point-label {
-            position: absolute;
-            transform: translateY(-100%);
-            padding: 0px 5px;
-            border-radius: 9999px 9999px 9999px 0px;
-            color: white;
-            background-color: rgba(0, 0, 0, 0.5);
-            white-space: nowrap;
-        }
-        .crosshairs {
-            position: absolute;
-            transform: translate(-50%, -50%);
-        }
-        .crosshairs::before {
-            content: "";
-            position: absolute;
-            width: 12px;
-            height: 2px;
-            transform: translate(-50%, -50%);
-            background-color: red;
-        }
-        .crosshairs::after {
-            content: "";
-            position: absolute;
-            width: 2px;
-            height: 12px;
-            transform: translate(-50%, -50%);
-            background-color: red;
-        }
-        .number-input {
-            width: 40px;
-        }
-    </style>
-    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/OpenSeadragonScalebar/2.0.0/openseadragon-scalebar.min.css" />
-</head>
-<body>
+    <link
+      rel="stylesheet"
+      href="https://cdnjs.cloudflare.com/ajax/libs/OpenSeadragonScalebar/2.0.0/openseadragon-scalebar.min.css"
+    />
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
     <div id="viewer-container"></div>
     <div class="controls">
-        <div>
-            <input type="checkbox" id="image1" checked onclick="toggleImage(this, 0)" />
-            <label for="image1">XPL1</label>
-            <input type="checkbox" id="image2" checked onclick="toggleImage(this, 1)" />
-            <label for="image2">XPL2</label>
-            <input type="checkbox" id="image3" checked onclick="toggleImage(this, 2)" />
-            <label for="image3">PPL</label>
-        </div>
-        <hr>
-        <div>
-            <input type="checkbox" id="show-grid" checked onclick="toggleGrid(this)" />
-            <label for="show-grid">Show grid</label>
-            <details open>
-                <summary>Grid layout</summary>
-                <input id="pixels-per-unit" class="number-input" type="number" step="any" value="100" min="1" onchange="enableGridButtons()"></input>
-                pixels/
-                <select id="unit" onchange="enableGridButtons()">
-                    <option>m</option>
-                    <option>mm</option>
-                    <option>μm</option>
-                    <option>nm</option>
-                </select>
-                <div>
-                    <label for="grid-left">x<sub>min</sub>:</label>
-                    <input id="grid-left" class="number-input" type="number" step="any" min="0" onchange="enableGridButtons()"></input>
-                    <label for="grid-top">y<sub>min</sub>:</label>
-                    <input id="grid-top" class="number-input" type="number" step="any" min="0" onchange="enableGridButtons()"></input>
-                </div>
-                <div>
-                    <label for="grid-right">x<sub>max</sub>:</label>
-                    <input id="grid-right" class="number-input" type="number" step="any" onchange="enableGridButtons()"></input>
-                    <label for="grid-bottom">y<sub>max</sub>:</label>
-                    <input id="grid-bottom" class="number-input" type="number" step="any" onchange="enableGridButtons()"></input>
-                </div>
-                <div>
-                    <label for="row-count">rows:</label>
-                    <input id="row-count" class="number-input" type="number" min="2" onchange="enableGridButtons()"></input>
-                    <label for="col-count">columns:</label>
-                    <input id="col-count" class="number-input" type="number" min="2" onchange="enableGridButtons()"></input>
-                </div>
-                <button id="apply-grid-settings" onclick="applyGridSettings()">Apply</button>
-                <button id="restore-grid-settings" onclick="restoreGridSettings()" disabled>Restore</button>
-            </details>
-        </div>
-    </div>
+      <div>
+        <input
+          type="checkbox"
+          id="image1"
+          checked
+          onclick="toggleImage(this, 0)"
+        />
+        <label for="image1">XPL1</label>
+        <input
+          type="checkbox"
+          id="image2"
+          checked
+          onclick="toggleImage(this, 1)"
+        />
+        <label for="image2">XPL2</label>
+        <input
+          type="checkbox"
+          id="image3"
+          checked
+          onclick="toggleImage(this, 2)"
+        />
+        <label for="image3">PPL</label>
+      </div>
+      <hr />
+      <div>
+        <input
+          type="checkbox"
+          id="show-grid"
+          checked
+          onclick="toggleGrid(this)"
+        />
+        <label for="show-grid">Show grid</label>
+        <details open>
+          <summary>Grid layout</summary>
+          <input
+            id="pixels-per-unit"
+            class="number-input"
+            type="number"
+            step="any"
+            value="100"
+            min="1"
+            onchange="enableGridButtons()"
+          />
+          pixels/
+          <select id="unit" onchange="enableGridButtons()">
+            <option>m</option>
+            <option>mm</option>
+            <option>μm</option>
+            <option>nm</option>
+          </select>
+          <div>
+            <label for="grid-left">x<sub>min</sub>:</label>
+            <input
+              id="grid-left"
+              class="number-input"
+              type="number"
+              step="any"
+              min="0"
+              onchange="enableGridButtons()"
+            />
+            <label for="grid-top">y<sub>min</sub>:</label>
+            <input
+              id="grid-top"
+              class="number-input"
+              type="number"
+              step="any"
+              min="0"
+              onchange="enableGridButtons()"
+            />
+          </div>
+          <div>
+            <label for="grid-right">x<sub>max</sub>:</label>
+            <input
+              id="grid-right"
+              class="number-input"
+              type="number"
+              step="any"
+              onchange="enableGridButtons()"
+            />
+            <label for="grid-bottom">y<sub>max</sub>:</label>
+            <input
+              id="grid-bottom"
+              class="number-input"
+              type="number"
+              step="any"
+              onchange="enableGridButtons()"
+            />
+          </div>
+          <div>
+            <label for="row-count">rows:</label>
+            <input
+              id="row-count"
+              class="number-input"
+              type="number"
+              min="2"
+              onchange="enableGridButtons()"
+            />
+            <label for="col-count">columns:</label>
+            <input
+              id="col-count"
+              class="number-input"
+              type="number"
+              min="2"
+              onchange="enableGridButtons()"
+            />
+          </div>
+          <button id="apply-grid-settings" onclick="applyGridSettings()">
+            Apply
+          </button>
+          <button
+            id="restore-grid-settings"
+            onclick="restoreGridSettings()"
+            disabled
+          >
+            Restore
+          </button>
+        </details>
+      </div>
     </div>
     <script src="js/openseadragon.min.js"></script>
     <script src="js/openseadragon-scalebar.min.js"></script>
-    <script>
-        const viewer = OpenSeadragon({
-            maxZoomPixelRatio: 100,
-            id: "viewer-container",
-            prefixUrl: "js/images/",
-            tileSources: [
-                "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi",
-                "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013b.dzi",
-                "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-014.dzi",
-            ]
-        });
-
-        const viewerContainer = document.getElementById('viewer-container');
-
-        // Share the mouse position between event handlers.
-        let mousePos = new OpenSeadragon.Point(0, 0);
-
-        // Divides the images at the current mouse position, clipping overlaid
-        // images to expose the images underneath. Note that all images are
-        // expected to have the same position and size.
-        const divideImages = () => {
-            // Bail out if there are no images.
-            if (viewer.world.getItemCount() == 0) {
-                return;
-            }
-
-            // Get the clip point and clamp it to within the image bounds.
-            const image = viewer.world.getItemAt(0);
-            const clipPos = image.viewerElementToImageCoordinates(mousePos);
-            const size = image.getContentSize();
-            clipPos.x = Math.max(0, Math.min(clipPos.x, size.x));
-            clipPos.y = Math.max(0, Math.min(clipPos.y, size.y));
-
-            // Set the clip for each image.
-            let previousVisibleImages = 0;
-            for (let i = 0; i < viewer.world.getItemCount(); ++i) {
-                const image = viewer.world.getItemAt(i);
-                if (!image.getOpacity()) {
-                    continue;
-                }
-                // Determine the quadrants to be clipped by how many visible
-                // images are underneath this one.
-                const xClip = previousVisibleImages & 1 ? clipPos.x : 0;
-                const yClip = previousVisibleImages & 2 ? clipPos.y : 0;
-                image.setClip(new OpenSeadragon.Rect(xClip, yClip, size.x, size.y));
-                ++previousVisibleImages;
-            }
-        };
-
-        const toggleImage = (checkbox, idx) => {
-            viewer.world.getItemAt(idx).setOpacity(checkbox.checked ? 1 : 0);
-            divideImages();
-        };
-
-        const toggleGrid = event => {
-            for (let el of document.getElementsByClassName("grid")) {
-                el.style.visibility = event.checked ? "visible" : "hidden";
-            }
-        };
-
-        viewer.addHandler('animation', divideImages);
-
-        viewerContainer.addEventListener('pointermove', event => {
-            mousePos = new OpenSeadragon.Point(event.clientX, event.clientY)
-            divideImages();
-        });
-
-        // Initialize the scalebar, except for pixelsPerMeter, which depends on
-        // the grid settings.
-        viewer.scalebar({
-            type: OpenSeadragon.ScalebarType.MAP,
-            minWidth: "75px",
-            location: OpenSeadragon.ScalebarLocation.BOTTOM_LEFT,
-            xOffset: 10,
-            yOffset: 10,
-            stayInsideImage: true,
-            color: "black",
-            fontColor: "black",
-            backgroundColor: "rgba(255, 255, 255, 0.5)",
-            fontSize: "small",
-            barThickness: 2
-        });
-
-        const Grid = class {
-            constructor({unit, pixelsPerUnit, xMin, yMin, xMax, yMax, rows, cols}) {
-                this.unit = unit;
-                this.pixelsPerUnit = pixelsPerUnit;
-                this.xMin = xMin;
-                this.yMin = yMin;
-                this.xMax = xMax;
-                this.yMax = yMax;
-                this.rows = rows;
-                this.cols = cols;
-            }
-
-            get metersPerUnit() {
-                return 10 ** (-3 * this.unit);
-            }
-
-            get unitName() {
-                switch (this.unit) {
-                    case 0:
-                        return "m";
-                    case 1:
-                        return "mm";
-                    case 2:
-                        return "μm";
-                    case 3:
-                        return "nm";
-                }
-            }
-
-            get pixelsPerMeter() {
-                return this.pixelsPerUnit / this.metersPerUnit;
-            }
-        };
-
-        // Initialize grid with default settings.
-        let grid = new Grid({
-            unit: 1,
-            pixelsPerUnit: 100,
-            xMin: 1,
-            yMin: 3,
-            xMax: 48,
-            yMax: 28,
-            rows: 10,
-            cols: 10,
-        });
-        let gridApplied = false;
-
-        const enableGridButtons = () => {
-            document.getElementById("apply-grid-settings").disabled = false;
-            document.getElementById("restore-grid-settings").disabled = false;
-        };
-
-        const applyGridSettings = () => {
-            viewer.clearOverlays();
-
-            const image = viewer.world.getItemAt(0);
-            grid = new Grid({
-                unit: document.getElementById("unit").selectedIndex,
-                pixelsPerUnit: parseFloat(document.getElementById("pixels-per-unit").value),
-                xMin: parseFloat(document.getElementById("grid-left").value),
-                yMin: parseFloat(document.getElementById("grid-top").value),
-                xMax: parseFloat(document.getElementById("grid-right").value),
-                yMax: parseFloat(document.getElementById("grid-bottom").value),
-                rows: parseInt(document.getElementById("row-count").value),
-                cols: parseInt(document.getElementById("col-count").value),
-            });
-
-            for (let row = 0; row < grid.rows; ++row) {
-                for (let col = 0; col < grid.cols; ++col) {
-                    // Alternate column order per row.
-                    const altCol = row % 2 == 0 ? col : grid.cols - col - 1;
-
-                    // Get the coordinates in the specified unit.
-                    const xUnits = grid.xMin + altCol * (grid.xMax - grid.xMin) / (grid.cols - 1);
-                    const yUnits = grid.yMin + row * (grid.yMax - grid.yMin) / (grid.rows - 1);
-
-                    // Convert to coordinates in pixels.
-                    const xPixels = xUnits * grid.metersPerUnit * grid.pixelsPerMeter;
-                    const yPixels = yUnits * grid.metersPerUnit * grid.pixelsPerMeter;
-
-                    // Convert to view-space coordinates, measuring from the
-                    // top-left of the first image.
-                    const location = image.imageToViewportCoordinates(xPixels, yPixels);
-
-                    // Add point label with coordinates.
-                    const pointLabel = document.createElement("div");
-                    pointLabel.innerHTML = `${1 + col + row * grid.cols}`;                    
-                    // pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${grid.unitName}, ${yUnits.toPrecision(3)} ${grid.unitName})`;
-                    pointLabel.className = "grid point-label";
-                    viewer.addOverlay({
-                        element: pointLabel,
-                        location: location,
-                        checkResize: false,
-                    });
-
-                    // Add crosshairs.
-                    const crosshairs = document.createElement("div");
-                    crosshairs.className = "grid crosshairs";
-                    viewer.addOverlay({
-                        element: crosshairs,
-                        location: location,
-                        checkResize: false,
-                    });
-                }
-            }
-
-            // Update scalebar scale.
-            viewer.scalebar({pixelsPerMeter: grid.pixelsPerMeter});
-
-            // Always show the grid right after generating it. (The newly added
-            // overlay elements will be visible by default, so checking the box
-            // here doesn't actually affect them - it just makes the checkbox
-            // state consistent with the visibility states.)
-            document.getElementById("show-grid").checked = true;
-
-            document.getElementById("apply-grid-settings").disabled = true;
-            document.getElementById("restore-grid-settings").disabled = true;
-            gridApplied = true;
-        };
-
-        const restoreGridSettings = () => {
-            document.getElementById("unit").selectedIndex = grid.unit;
-            document.getElementById("pixels-per-unit").value = grid.pixelsPerUnit;
-            document.getElementById("grid-left").value = grid.xMin;
-            document.getElementById("grid-top").value = grid.yMin;
-            document.getElementById("grid-right").value = grid.xMax;
-            document.getElementById("grid-bottom").value = grid.yMax;
-            document.getElementById("row-count").value = grid.rows;
-            document.getElementById("col-count").value = grid.cols;
-
-            // Leave the Apply button enabled unless the grid has been generated
-            // at least once.
-            if (gridApplied) {
-                document.getElementById("apply-grid-settings").disabled = true;
-            }
-            document.getElementById("restore-grid-settings").disabled = true;
-        }
-
-        // Initialize grid setting elements.
-        restoreGridSettings();
-    </script>
-</body>
+    <script src="index.js"></script>
+  </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -14,9 +14,9 @@ const viewerContainer = document.getElementById("viewer-container");
 // Share the mouse position between event handlers.
 let mousePos = new OpenSeadragon.Point(0, 0);
 
-// Divides the images at the current mouse position, clipping overlaid
-// images to expose the images underneath. Note that all images are
-// expected to have the same position and size.
+// Divides the images at the current mouse position, clipping overlaid images to
+// expose the images underneath. Note that all images are expected to have the
+// same position and size.
 const divideImages = () => {
   // Bail out if there are no images.
   if (viewer.world.getItemCount() == 0) {
@@ -37,8 +37,8 @@ const divideImages = () => {
     if (!image.getOpacity()) {
       continue;
     }
-    // Determine the quadrants to be clipped by how many visible
-    // images are underneath this one.
+    // Determine the quadrants to be clipped by how many visible images are
+    // underneath this one.
     const xClip = previousVisibleImages & 1 ? clipPos.x : 0;
     const yClip = previousVisibleImages & 2 ? clipPos.y : 0;
     image.setClip(new OpenSeadragon.Rect(xClip, yClip, size.x, size.y));
@@ -64,8 +64,8 @@ viewerContainer.addEventListener("pointermove", (event) => {
   divideImages();
 });
 
-// Initialize the scalebar, except for pixelsPerMeter, which depends on
-// the grid settings.
+// Initialize the scalebar, except for pixelsPerMeter, which depends on the grid
+// settings.
 viewer.scalebar({
   type: OpenSeadragon.ScalebarType.MAP,
   minWidth: "75px",
@@ -162,14 +162,13 @@ const applyGridSettings = () => {
       const xPixels = xUnits * grid.metersPerUnit * grid.pixelsPerMeter;
       const yPixels = yUnits * grid.metersPerUnit * grid.pixelsPerMeter;
 
-      // Convert to view-space coordinates, measuring from the
-      // top-left of the first image.
+      // Convert to view-space coordinates, measuring from the top-left of the
+      // first image.
       const location = image.imageToViewportCoordinates(xPixels, yPixels);
 
       // Add point label with coordinates.
       const pointLabel = document.createElement("div");
       pointLabel.innerHTML = `${1 + col + row * grid.cols}`;
-      // pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${grid.unitName}, ${yUnits.toPrecision(3)} ${grid.unitName})`;
       pointLabel.className = "grid point-label";
       viewer.addOverlay({
         element: pointLabel,
@@ -191,10 +190,10 @@ const applyGridSettings = () => {
   // Update scalebar scale.
   viewer.scalebar({ pixelsPerMeter: grid.pixelsPerMeter });
 
-  // Always show the grid right after generating it. (The newly added
-  // overlay elements will be visible by default, so checking the box
-  // here doesn't actually affect them - it just makes the checkbox
-  // state consistent with the visibility states.)
+  // Always show the grid right after generating it. (The newly added overlay
+  // elements will be visible by default, so checking the box here doesn't
+  // actually affect them - it just makes the checkbox state consistent with the
+  // visibility states.)
   document.getElementById("show-grid").checked = true;
 
   document.getElementById("apply-grid-settings").disabled = true;
@@ -212,8 +211,8 @@ const restoreGridSettings = () => {
   document.getElementById("row-count").value = grid.rows;
   document.getElementById("col-count").value = grid.cols;
 
-  // Leave the Apply button enabled unless the grid has been generated
-  // at least once.
+  // Leave the Apply button enabled unless the grid has been generated at least
+  // once.
   if (gridApplied) {
     document.getElementById("apply-grid-settings").disabled = true;
   }

--- a/index.js
+++ b/index.js
@@ -1,0 +1,224 @@
+const viewer = OpenSeadragon({
+  maxZoomPixelRatio: 100,
+  id: "viewer-container",
+  prefixUrl: "js/images/",
+  tileSources: [
+    "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013.dzi",
+    "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-013b.dzi",
+    "https://raw.githubusercontent.com/grsharman/petro-image/main/images/O48-014.dzi",
+  ],
+});
+
+const viewerContainer = document.getElementById("viewer-container");
+
+// Share the mouse position between event handlers.
+let mousePos = new OpenSeadragon.Point(0, 0);
+
+// Divides the images at the current mouse position, clipping overlaid
+// images to expose the images underneath. Note that all images are
+// expected to have the same position and size.
+const divideImages = () => {
+  // Bail out if there are no images.
+  if (viewer.world.getItemCount() == 0) {
+    return;
+  }
+
+  // Get the clip point and clamp it to within the image bounds.
+  const image = viewer.world.getItemAt(0);
+  const clipPos = image.viewerElementToImageCoordinates(mousePos);
+  const size = image.getContentSize();
+  clipPos.x = Math.max(0, Math.min(clipPos.x, size.x));
+  clipPos.y = Math.max(0, Math.min(clipPos.y, size.y));
+
+  // Set the clip for each image.
+  let previousVisibleImages = 0;
+  for (let i = 0; i < viewer.world.getItemCount(); ++i) {
+    const image = viewer.world.getItemAt(i);
+    if (!image.getOpacity()) {
+      continue;
+    }
+    // Determine the quadrants to be clipped by how many visible
+    // images are underneath this one.
+    const xClip = previousVisibleImages & 1 ? clipPos.x : 0;
+    const yClip = previousVisibleImages & 2 ? clipPos.y : 0;
+    image.setClip(new OpenSeadragon.Rect(xClip, yClip, size.x, size.y));
+    ++previousVisibleImages;
+  }
+};
+
+const toggleImage = (checkbox, idx) => {
+  viewer.world.getItemAt(idx).setOpacity(checkbox.checked ? 1 : 0);
+  divideImages();
+};
+
+const toggleGrid = (event) => {
+  for (let el of document.getElementsByClassName("grid")) {
+    el.style.visibility = event.checked ? "visible" : "hidden";
+  }
+};
+
+viewer.addHandler("animation", divideImages);
+
+viewerContainer.addEventListener("pointermove", (event) => {
+  mousePos = new OpenSeadragon.Point(event.clientX, event.clientY);
+  divideImages();
+});
+
+// Initialize the scalebar, except for pixelsPerMeter, which depends on
+// the grid settings.
+viewer.scalebar({
+  type: OpenSeadragon.ScalebarType.MAP,
+  minWidth: "75px",
+  location: OpenSeadragon.ScalebarLocation.BOTTOM_LEFT,
+  xOffset: 10,
+  yOffset: 10,
+  stayInsideImage: true,
+  color: "black",
+  fontColor: "black",
+  backgroundColor: "rgba(255, 255, 255, 0.5)",
+  fontSize: "small",
+  barThickness: 2,
+});
+
+const Grid = class {
+  constructor({ unit, pixelsPerUnit, xMin, yMin, xMax, yMax, rows, cols }) {
+    this.unit = unit;
+    this.pixelsPerUnit = pixelsPerUnit;
+    this.xMin = xMin;
+    this.yMin = yMin;
+    this.xMax = xMax;
+    this.yMax = yMax;
+    this.rows = rows;
+    this.cols = cols;
+  }
+
+  get metersPerUnit() {
+    return 10 ** (-3 * this.unit);
+  }
+
+  get unitName() {
+    switch (this.unit) {
+      case 0:
+        return "m";
+      case 1:
+        return "mm";
+      case 2:
+        return "μm";
+      case 3:
+        return "nm";
+    }
+  }
+
+  get pixelsPerMeter() {
+    return this.pixelsPerUnit / this.metersPerUnit;
+  }
+};
+
+// Initialize grid with default settings.
+let grid = new Grid({
+  unit: 1,
+  pixelsPerUnit: 100,
+  xMin: 1,
+  yMin: 3,
+  xMax: 48,
+  yMax: 28,
+  rows: 10,
+  cols: 10,
+});
+let gridApplied = false;
+
+const enableGridButtons = () => {
+  document.getElementById("apply-grid-settings").disabled = false;
+  document.getElementById("restore-grid-settings").disabled = false;
+};
+
+const applyGridSettings = () => {
+  viewer.clearOverlays();
+
+  const image = viewer.world.getItemAt(0);
+  grid = new Grid({
+    unit: document.getElementById("unit").selectedIndex,
+    pixelsPerUnit: parseFloat(document.getElementById("pixels-per-unit").value),
+    xMin: parseFloat(document.getElementById("grid-left").value),
+    yMin: parseFloat(document.getElementById("grid-top").value),
+    xMax: parseFloat(document.getElementById("grid-right").value),
+    yMax: parseFloat(document.getElementById("grid-bottom").value),
+    rows: parseInt(document.getElementById("row-count").value),
+    cols: parseInt(document.getElementById("col-count").value),
+  });
+
+  for (let row = 0; row < grid.rows; ++row) {
+    for (let col = 0; col < grid.cols; ++col) {
+      // Alternate column order per row.
+      const altCol = row % 2 == 0 ? col : grid.cols - col - 1;
+
+      // Get the coordinates in the specified unit.
+      const xUnits =
+        grid.xMin + (altCol * (grid.xMax - grid.xMin)) / (grid.cols - 1);
+      const yUnits =
+        grid.yMin + (row * (grid.yMax - grid.yMin)) / (grid.rows - 1);
+
+      // Convert to coordinates in pixels.
+      const xPixels = xUnits * grid.metersPerUnit * grid.pixelsPerMeter;
+      const yPixels = yUnits * grid.metersPerUnit * grid.pixelsPerMeter;
+
+      // Convert to view-space coordinates, measuring from the
+      // top-left of the first image.
+      const location = image.imageToViewportCoordinates(xPixels, yPixels);
+
+      // Add point label with coordinates.
+      const pointLabel = document.createElement("div");
+      pointLabel.innerHTML = `${1 + col + row * grid.cols}`;
+      // pointLabel.innerHTML = `${1 + col + row * grid.cols} (${xUnits.toPrecision(3)} ${grid.unitName}, ${yUnits.toPrecision(3)} ${grid.unitName})`;
+      pointLabel.className = "grid point-label";
+      viewer.addOverlay({
+        element: pointLabel,
+        location: location,
+        checkResize: false,
+      });
+
+      // Add crosshairs.
+      const crosshairs = document.createElement("div");
+      crosshairs.className = "grid crosshairs";
+      viewer.addOverlay({
+        element: crosshairs,
+        location: location,
+        checkResize: false,
+      });
+    }
+  }
+
+  // Update scalebar scale.
+  viewer.scalebar({ pixelsPerMeter: grid.pixelsPerMeter });
+
+  // Always show the grid right after generating it. (The newly added
+  // overlay elements will be visible by default, so checking the box
+  // here doesn't actually affect them - it just makes the checkbox
+  // state consistent with the visibility states.)
+  document.getElementById("show-grid").checked = true;
+
+  document.getElementById("apply-grid-settings").disabled = true;
+  document.getElementById("restore-grid-settings").disabled = true;
+  gridApplied = true;
+};
+
+const restoreGridSettings = () => {
+  document.getElementById("unit").selectedIndex = grid.unit;
+  document.getElementById("pixels-per-unit").value = grid.pixelsPerUnit;
+  document.getElementById("grid-left").value = grid.xMin;
+  document.getElementById("grid-top").value = grid.yMin;
+  document.getElementById("grid-right").value = grid.xMax;
+  document.getElementById("grid-bottom").value = grid.yMax;
+  document.getElementById("row-count").value = grid.rows;
+  document.getElementById("col-count").value = grid.cols;
+
+  // Leave the Apply button enabled unless the grid has been generated
+  // at least once.
+  if (gridApplied) {
+    document.getElementById("apply-grid-settings").disabled = true;
+  }
+  document.getElementById("restore-grid-settings").disabled = true;
+};
+
+// Initialize grid setting elements.
+restoreGridSettings();

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const viewer = OpenSeadragon({
   maxZoomPixelRatio: 100,
   id: "viewer-container",

--- a/style.css
+++ b/style.css
@@ -1,0 +1,57 @@
+body,
+html {
+  margin: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+#viewer-container {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.controls {
+  position: absolute;
+  top: 40px;
+  left: 5px;
+  border: 1px solid black;
+  border-radius: 4px;
+  padding: 5px;
+  background-color: rgba(255, 255, 255, 0.75);
+}
+
+.point-label {
+  position: absolute;
+  transform: translateY(-100%);
+  padding: 0px 5px;
+  border-radius: 9999px 9999px 9999px 0px;
+  color: white;
+  background-color: rgba(0, 0, 0, 0.5);
+  white-space: nowrap;
+}
+
+.crosshairs {
+  position: absolute;
+  transform: translate(-50%, -50%);
+}
+.crosshairs::before {
+  content: "";
+  position: absolute;
+  width: 12px;
+  height: 2px;
+  transform: translate(-50%, -50%);
+  background-color: red;
+}
+.crosshairs::after {
+  content: "";
+  position: absolute;
+  width: 2px;
+  height: 12px;
+  transform: translate(-50%, -50%);
+  background-color: red;
+}
+
+.number-input {
+  width: 40px;
+}


### PR DESCRIPTION
This PR moves the inline CSS and JavaScript out of `index.html` and into separate files, for better maintainability. In addition, I fixed some malformed HTML and formatted all three documents using [Prettier](https://prettier.io/)'s default formatting settings.

Finally, I added [the "use strict" directive](https://www.w3schools.com/js/js_strict.asp) to the JavaScript file, to opt into better language safety. This is the only change that could have a functional effect (by turning some silent bugs into errors), but nothing turned up, so no other changes were required.

Needless to say, this PR should be resolved before anyone does additional work on the CSS or JavaScript, to avoid massive merge conflicts.