### PR TITLE
A couple of fixes for image indexing in the cycle_angles branch

### DIFF
--- a/index.js
+++ b/index.js
@@ -591,12 +591,23 @@ const toggleImage = (checkbox, idx) => {
   console.log(`image${idx + 1}Opacity`, imageOpacity);
 
   const tileSet = tileSets[currentIndex];
+  const tile = tileSet[idx];
 
-  // Check if the item at idx is a nested list or a single image
-  if (Array.isArray(tileSet[idx])) {
+  // Find the index of the first image belonging to the checked tile.
+  let firstImageIdx = 0;
+  for (let i = 0; i < idx; ++i) {
+    if (Array.isArray(tileSet[i])) {
+      firstImageIdx += tileSet[i].length;
+    } else {
+      ++firstImageIdx;
+    }
+  }
+
+  // Check if the tile is a nested list or a single image
+  if (Array.isArray(tile)) {
     // If it's a nested array, loop through the images
-    tileSet[idx].forEach((tileSource, nestedIndex) => {
-      const imageIndex = idx + nestedIndex; // Add nestedIndex to calculate the correct image index
+    tile.forEach((_, nestedIndex) => {
+      const imageIndex = firstImageIdx + nestedIndex; // Add nestedIndex to calculate the correct image index
       const image = viewer.world.getItemAt(imageIndex);
       if (image) {
         image.setOpacity(checkbox.checked ? imageOpacity / 100 : 0);
@@ -604,7 +615,7 @@ const toggleImage = (checkbox, idx) => {
     });
   } else {
     // If it's a single image, handle it directly
-    const image = viewer.world.getItemAt(idx);
+    const image = viewer.world.getItemAt(firstImageIdx);
     if (image) {
       image.setOpacity(checkbox.checked ? imageOpacity / 100 : 0);
     }

--- a/index.js
+++ b/index.js
@@ -420,10 +420,11 @@ function setTileSetOpacity() {
 
     const opacityValue =
       Number(document.getElementById(`opacityImage${i + 1}`).value) / 100; // Convert percent
-    if (document.getElementById(`image${i + 1}`).checked) {
-      for (let j = 0; j < imagesInQuadrant.length; ++j) {
-        const tiledImage = viewer.world.getItemAt(imageIndex);
-        ++imageIndex;
+    const checked = document.getElementById(`image${i + 1}`).checked;
+    for (let j = 0; j < imagesInQuadrant.length; ++j) {
+      ++imageIndex;
+      if (checked) {
+        const tiledImage = viewer.world.getItemAt(imageIndex - 1);
         if (tiledImage) {
           if (j === visibleImageIndex) {
             tiledImage.setOpacity(opacityValue);


### PR DESCRIPTION
Addresses https://github.com/grsharman/petro-image/issues/30

This fixes a couple of bugs related to image indexing:

1. a97d1562346fb84ff83e087373434716721c9ae6 fixes (I think) a bug in `toggleImage` that would cause the image indexing to go off the rails for tiles preceded by tiles with multiple images. This behavior wasn't apparent from the first example tile set since in that example, the first tile only has one image. However, I think it would have shown up sooner or later.
2. f1794d907dcde27157f532702f41b566c2f7e399 fixes a similar bug in `setTileSetOpacity` causing the wrong images to be modified when tiles were hidden.

Tiles no longer being one-to-one with images adds a lot of complexity to the indexing logic, and I would not be surprised if there are additional latent indexing bugs. 👀 If you're sticking with an input structure where tiles can have a variable length, I would recommend defining a function to abstract away the indexing calculations. For example, a `function getImageIdx(tileIdx, currentImageIdx)` that takes the index of the tile within the tile set and the index of the image within that tile and returns the global image index.